### PR TITLE
Feature - Add year_month to DynamoDB

### DIFF
--- a/add-year-month/functions/dynamodb.py
+++ b/add-year-month/functions/dynamodb.py
@@ -1,0 +1,24 @@
+import boto3
+import os
+
+def db_put(id, year_month):
+    table = os.environ['DynamoDBTable']
+    client = boto3.client('dynamodb')
+
+    print(f'Updating {id} with {year_month}')
+
+    return client.update_item(
+        TableName=table,
+        Key={
+            'id': {
+                'S': id
+            }
+        },
+        AttributeUpdates={
+                'year_month': {
+                        'Value': {
+                            'S': str(year_month)
+                        }
+                }
+        }
+    )

--- a/add-year-month/index.py
+++ b/add-year-month/index.py
@@ -1,0 +1,24 @@
+import boto3
+import os
+
+from datetime import datetime
+from functions.dynamodb import db_put
+
+def handler(event, context):
+    table = os.environ['DynamoDBTable']
+    print(f'Accessing {table}')
+
+    client = boto3.client('dynamodb')
+    response = client.scan(
+        TableName=table
+    )
+
+    results = response['Items']
+
+    for result in results:
+        if not 'year_month' in result:
+            id = result['id']['S']
+            datetime_object = datetime.strptime(id, '%Y-%m-%d, %H:%M:%S:%f')
+            year_month = datetime_object.strftime('%Y-%m')
+            result_db_put = db_put(id, year_month)
+            print(id, result_db_put)

--- a/template.yaml
+++ b/template.yaml
@@ -190,7 +190,7 @@ Resources:
       Handler: index.handler
       Runtime: python3.9
       CodeUri: add-year-month
-      Timeout: 300
+      Timeout: 840 # 14 minutes
       Environment:
         Variables:
           DynamoDBTable: !Ref DynamoDB

--- a/template.yaml
+++ b/template.yaml
@@ -183,3 +183,17 @@ Resources:
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref DynamoDB
+
+  LambdaAddYearMonth:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      Handler: index.handler
+      Runtime: python3.9
+      CodeUri: add-year-month
+      Timeout: 300
+      Environment:
+        Variables:
+          DynamoDBTable: !Ref DynamoDB
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref DynamoDB


### PR DESCRIPTION
It's difficult to filter / sort / generate new index without another unique/sort key.
