### PR TITLE
Migrate from cloudformation_output.py to Lambda Variables

### DIFF
--- a/python/functions/cloudformation_output.py
+++ b/python/functions/cloudformation_output.py
@@ -6,16 +6,22 @@ def parameters(output_keys):
     for output in output_keys:
         if output['OutputKey'] == 'RefreshToken':
             refresh_token = output['OutputValue']
+
         elif output['OutputKey'] == 'ClientSecret':
             client_secret = output['OutputValue']
+
         elif output['OutputKey'] == 'ClientID':
             client_id = output['OutputValue']
+
         elif output['OutputKey'] == 'RedirectUri':
             redirect_uri = output['OutputValue']
+
         elif output['OutputKey'] == 'CurrentTrack':
             current_track = output['OutputValue']
+
         elif output['OutputKey'] == 'Table':
             table = output['OutputValue']
+
         elif output['OutputKey'] == 'Topic':
             topic = output['OutputValue']
 

--- a/python/index.py
+++ b/python/index.py
@@ -38,9 +38,11 @@ def handler(event, context):
             StackName='spotify-tracker-sam'
         )
 
-        output_keys = response['Stacks'][0]['Outputs']
+        feature_scan_cft = False
+        if feature_scan_cft:
+            output_keys = response['Stacks'][0]['Outputs']
 
-        refresh_token_parameter, refresh_token, client_secret, client_id, redirect_uri, current_track_parameter, current_track, table, topic = cloudformation_output.get(output_keys)
+            refresh_token_parameter, refresh_token, client_secret, client_id, redirect_uri, current_track_parameter, current_track, table, topic = cloudformation_output.get(output_keys)
 
         v_spotify_refresh_token_parameter = os.environ['ParameterSpotifyRefreshToken']
         v_spotify_refresh_token_parameter_value = ssm.get(v_spotify_refresh_token_parameter)

--- a/python/index.py
+++ b/python/index.py
@@ -10,6 +10,7 @@ import functions.player as player
 import functions.dynamodb as dynamodb
 import functions.notify as notify
 import functions.eventbridge as eventbridge
+import functions.ssm as ssm
 import base64
 
 def handler(event, context):
@@ -40,6 +41,20 @@ def handler(event, context):
         output_keys = response['Stacks'][0]['Outputs']
 
         refresh_token_parameter, refresh_token, client_secret, client_id, redirect_uri, current_track_parameter, current_track, table, topic = cloudformation_output.get(output_keys)
+
+        v_spotify_refresh_token_parameter = os.environ['ParameterSpotifyRefreshToken']
+        v_spotify_refresh_token_parameter_value = ssm.get(v_spotify_refresh_token_parameter)
+
+        v_spotify_client_id = ssm.get(os.environ['ParameterSpotifyClientID'])
+        v_spotfiy_client_secret = ssm.get(os.environ['ParameterSpotifyClientSecret'])
+
+        v_redirect_uri = os.environ['RedirectUri']
+
+        v_current_track_parameter = os.environ['ParameterCurrentTrack']
+        v_current_track_parameter_value = ssm.get(v_current_track_parameter)
+
+        v_table = os.environ['Table']
+        v_topic = os.environ['Topic']
 
         access_token = authorization.get_refresh_token(refresh_token, client_id, client_secret, refresh_token_parameter)['access_token']
 

--- a/python/index.py
+++ b/python/index.py
@@ -44,21 +44,20 @@ def handler(event, context):
 
             refresh_token_parameter, refresh_token, client_secret, client_id, redirect_uri, current_track_parameter, current_track, table, topic = cloudformation_output.get(output_keys)
 
-        v_spotify_refresh_token_parameter = os.environ['ParameterSpotifyRefreshToken']
-        v_spotify_refresh_token_parameter_value = ssm.get(v_spotify_refresh_token_parameter)
+        spotify_refresh_token_parameter = os.environ['ParameterSpotifyRefreshToken']
+        spotify_refresh_token_parameter_value = ssm.get(spotify_refresh_token_parameter)
 
-        v_spotify_client_id = ssm.get(os.environ['ParameterSpotifyClientID'])
-        v_spotfiy_client_secret = ssm.get(os.environ['ParameterSpotifyClientSecret'])
+        client_id = ssm.get(os.environ['ParameterSpotifyClientID'])
+        client_secret = ssm.get(os.environ['ParameterSpotifyClientSecret'])
 
-        v_redirect_uri = os.environ['RedirectUri']
+        redirect_uri = os.environ['RedirectUri']
 
-        v_current_track_parameter = os.environ['ParameterCurrentTrack']
-        v_current_track_parameter_value = ssm.get(v_current_track_parameter)
+        current_track_parameter = os.environ['ParameterCurrentTrack']
 
-        v_table = os.environ['Table']
-        v_topic = os.environ['Topic']
+        table = os.environ['Table']
+        topic = os.environ['Topic']
 
-        access_token = authorization.get_refresh_token(refresh_token, client_id, client_secret, refresh_token_parameter)['access_token']
+        access_token = authorization.get_refresh_token(spotify_refresh_token_parameter_value, client_id, client_secret, spotify_refresh_token_parameter)['access_token']
 
         now_playing = (player.get(access_token, topic, client_id, redirect_uri))
 

--- a/template.yaml
+++ b/template.yaml
@@ -39,6 +39,8 @@ Resources:
           ParameterSpotifyRefreshToken: !Ref ParameterSpotifyRefreshToken
           CallbackURL: !Ref CallbackURL
           ParameterCurrentTrack: !Ref ParameterCurrentTrack
+          Table: !Ref DynamoDB
+          Topic: !Ref Topic
       Events:
         EventBridge:
             Type: Schedule

--- a/template.yaml
+++ b/template.yaml
@@ -41,6 +41,7 @@ Resources:
           ParameterCurrentTrack: !Ref ParameterCurrentTrack
           Table: !Ref DynamoDB
           Topic: !Ref Topic
+          RedirectUri: !Ref CallbackURL
       Events:
         EventBridge:
             Type: Schedule

--- a/template.yaml
+++ b/template.yaml
@@ -34,7 +34,11 @@ Resources:
       Environment:
         Variables:
           PreviousEntryEpochTime: !Ref ParameterPreviousEntryEpochTime
-
+          ParameterSpotifyClientID: !Ref ParameterSpotifyClientID
+          ParameterSpotifyClientSecret: !Ref ParameterSpotifyClientSecret
+          ParameterSpotifyRefreshToken: !Ref ParameterSpotifyRefreshToken
+          CallbackURL: !Ref CallbackURL
+          ParameterCurrentTrack: !Ref ParameterCurrentTrack
       Events:
         EventBridge:
             Type: Schedule


### PR DESCRIPTION
This PR migrates the variables based on the CFT Outputs to Lambda Variables.

I originally did not know of/thought about making the CloudFormation Outputs to Lambda Variables. It's basically the same thing: reference the SSM Parameter. 

Except, I had made it complicated and scanned the CFT Outputs and looped through them.