### PR TITLE
Track Created Shuffle Liked Playlist

### DIFF
--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/authorization.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/authorization.py
@@ -26,7 +26,7 @@ def get_access_token():
         refresh_token = response_json['refresh_token']
         if not ssm_refresh_token == refresh_token:
             print(f'Updating Refresh Token')
-            put_parameter(refresh_token)
+            parameter_SpotifyRefreshToken = os.environ['SpotifyRefreshToken']
+            put_parameter(parameter=parameter_SpotifyRefreshToken,value=refresh_token)
 
     return access_token
-

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/dynamodb.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/dynamodb.py
@@ -1,0 +1,16 @@
+import os
+import boto3
+
+client = boto3.client('dynamodb')
+
+def put_item(playlist_id):
+    response = client.put_item(
+        TableName = os.environ['TableName'],
+        Item = {
+            'id' : {
+                'S' : playlist_id
+            }
+        }
+    )
+
+    print(response)

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/dynamodb.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/dynamodb.py
@@ -3,14 +3,26 @@ import boto3
 
 client = boto3.client('dynamodb')
 
-def put_item(playlist_id):
+def put_item(playlist_information):
+    id = playlist_information['id']
+    name = playlist_information['name']
+    url = playlist_information['external_urls']['spotify']
+    snapshot_id = playlist_information['snapshot_id']
+
     response = client.put_item(
         TableName = os.environ['TableName'],
         Item = {
             'id' : {
-                'S' : playlist_id
-            }
+                'S' : id
+            },
+            'name' : {
+                'S' : name
+            },
+            'url' : {
+                'S': url
+            },
+            'snapshot_id' : {
+                'S' : snapshot_id
+            },
         }
     )
-
-    print(response)

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
@@ -52,3 +52,4 @@ def create_shuffled_playlist(access_token, tracks):
     else:
         response_json = json.loads(response.content)
         print(response_json)
+        return playlist_id

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
@@ -53,3 +53,16 @@ def create_shuffled_playlist(access_token, tracks):
         response_json = json.loads(response.content)
         print(response_json)
         return playlist_id
+
+# https://developer.spotify.com/documentation/general/guides/working-with-playlists/#following-and-unfollowing-a-playlist
+def unfollow_playlist(access_token, playlist_id):
+    spotify_url = f'https://api.spotify.com/v1/playlists/{playlist_id}/followers'
+
+    headers = {
+        'Authorization' : 'Bearer ' + str(access_token),
+        'Content-Type' : 'application/json'
+    }
+
+    response = requests.delete(spotify_url)
+    # Getting 401 unauthorized even though the token is fine.
+    print(response)

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
@@ -1,6 +1,7 @@
 import json
 import requests
 
+from .dynamodb import put_item
 from .utils import current_year_month_day
 
 def create_playlist(access_token):
@@ -26,6 +27,7 @@ def create_playlist(access_token):
         print(f'Player Content: {response.content}')
     else:
         response_json = json.loads(response.content)
+        put_item(playlist_information=response_json)
         return response_json['id']
 
 def create_shuffled_playlist(access_token, tracks):

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/playlist.py
@@ -66,3 +66,14 @@ def unfollow_playlist(access_token, playlist_id):
     response = requests.delete(spotify_url)
     # Getting 401 unauthorized even though the token is fine.
     print(response)
+
+def check_user_follows_playlist(access_token, playlist_id):
+    spotify_url = f'https://api.spotify.com/v1/playlists/{playlist_id}/contains'
+
+    headers = {
+        'Authorization' : 'Bearer ' + str(access_token),
+        'Content-Type' : 'application/json'
+    }
+
+    response = requests.get(spotify_url)
+    print(response)

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/ssm.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/ssm.py
@@ -12,6 +12,6 @@ def put_parameter(parameter, value):
     client.put_parameter(
         Name = parameter,
         Value = value,
-        Type = 'Standard',
+        Type = 'String',
         Overwrite = True
     )

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/functions/ssm.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/functions/ssm.py
@@ -8,8 +8,7 @@ def get_parameter(parameter):
         Name=parameter
     )['Parameter']['Value']
 
-def put_parameter(value):
-    parameter = os.environ['SpotifyRefreshToken']
+def put_parameter(parameter, value):
     client.put_parameter(
         Name = parameter,
         Value = value,

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/index.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/index.py
@@ -3,7 +3,7 @@ import os
 from functions.authorization import get_access_token
 from functions.player import get_saved_tracks
 from functions.utils import handle_saved_tracks, shuffle_tracks
-from functions.playlist import create_playlist, create_shuffled_playlist
+from functions.playlist import create_playlist, create_shuffled_playlist, unfollow_playlist
 from functions.ssm import put_parameter
 
 def handler(event, context):
@@ -11,5 +11,8 @@ def handler(event, context):
     tracks = get_saved_tracks(access_token)
     shuffled_tracks = shuffle_tracks(handle_saved_tracks(tracks))
     new_playlist_id = create_shuffled_playlist(access_token=access_token, tracks=shuffled_tracks)
+
+    # Receive New Playlist Id and Delete Old Playlist
     parameter_ShuffledLikedPlaylistId = os.environ['ShuffledLikedPlaylistId']
+    unfollow_playlist(access_token=access_token, playlist_id=parameter_ShuffledLikedPlaylistId)
     put_parameter(parameter=parameter_ShuffledLikedPlaylistId, value=new_playlist_id)

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/index.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/index.py
@@ -1,10 +1,15 @@
+import os
+
 from functions.authorization import get_access_token
 from functions.player import get_saved_tracks
 from functions.utils import handle_saved_tracks, shuffle_tracks
 from functions.playlist import create_playlist, create_shuffled_playlist
+from functions.ssm import put_parameter
 
 def handler(event, context):
     access_token = get_access_token()
     tracks = get_saved_tracks(access_token)
     shuffled_tracks = shuffle_tracks(handle_saved_tracks(tracks))
-    create_shuffled_playlist(access_token=access_token, tracks=shuffled_tracks)
+    new_playlist_id = create_shuffled_playlist(access_token=access_token, tracks=shuffled_tracks)
+    parameter_ShuffledLikedPlaylistId = os.environ['ShuffledLikedPlaylistId']
+    put_parameter(parameter=parameter_ShuffledLikedPlaylistId, value=new_playlist_id)

--- a/3_Utilities/shuffle-liked-tracks-playlist/code/index.py
+++ b/3_Utilities/shuffle-liked-tracks-playlist/code/index.py
@@ -3,7 +3,7 @@ import os
 from functions.authorization import get_access_token
 from functions.player import get_saved_tracks
 from functions.utils import handle_saved_tracks, shuffle_tracks
-from functions.playlist import create_playlist, create_shuffled_playlist, unfollow_playlist
+from functions.playlist import create_playlist, create_shuffled_playlist, unfollow_playlist, check_user_follows_playlist
 from functions.ssm import put_parameter
 
 def handler(event, context):
@@ -12,7 +12,9 @@ def handler(event, context):
     shuffled_tracks = shuffle_tracks(handle_saved_tracks(tracks))
     new_playlist_id = create_shuffled_playlist(access_token=access_token, tracks=shuffled_tracks)
 
+    # Receiving 401 right now. Need to investigate the right authorization scope.
     # Receive New Playlist Id and Delete Old Playlist
-    parameter_ShuffledLikedPlaylistId = os.environ['ShuffledLikedPlaylistId']
-    unfollow_playlist(access_token=access_token, playlist_id=parameter_ShuffledLikedPlaylistId)
-    put_parameter(parameter=parameter_ShuffledLikedPlaylistId, value=new_playlist_id)
+    # parameter_ShuffledLikedPlaylistId = os.environ['ShuffledLikedPlaylistId']
+    # unfollow_playlist(access_token=access_token, playlist_id=parameter_ShuffledLikedPlaylistId)
+    # check_user_follows_playlist(access_token=access_token, playlist_id='6dppz7Cci1eoDdBFHIPPRe')
+    # put_parameter(parameter=parameter_ShuffledLikedPlaylistId, value=new_playlist_id)

--- a/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
+++ b/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
@@ -27,6 +27,8 @@ Resources:
             Enabled: true
             Schedule: cron(0 10 * * ? *)
       Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref Table
         - Statement:
           - Effect: Allow
             Action:

--- a/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
+++ b/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
@@ -30,7 +30,7 @@ Resources:
           SpotifyClientSecret: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyClientSecret
           SpotifyRefreshToken: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyRefreshToken
           TableName: !Ref Table
-          Parameter: !Ref Parameter
+          ShuffledLikedPlaylistId: !Ref Parameter
       Events:
         EventBridge:
           Type: Schedule

--- a/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
+++ b/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
@@ -6,6 +6,15 @@ Resources:
   Table:
     Type: AWS::Serverless::SimpleTable
     Properties: {}
+
+  Parameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Type: String
+      Value: example
+      Description: Spotify Latest Shuffled Liked Playlist ID
+      Tier: Standard
+
   Lambda:
     Type: 'AWS::Serverless::Function'
     Properties:
@@ -21,6 +30,7 @@ Resources:
           SpotifyClientSecret: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyClientSecret
           SpotifyRefreshToken: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyRefreshToken
           TableName: !Ref Table
+          Parameter: !Ref Parameter
       Events:
         EventBridge:
           Type: Schedule
@@ -47,3 +57,6 @@ Resources:
               - !Sub
                   - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${SpotifyRefreshToken}
                   - SpotifyRefreshToken: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyRefreshToken
+              - !Sub
+                  - arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Parameter}
+                  - Parameter: !Ref Parameter

--- a/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
+++ b/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
@@ -3,6 +3,9 @@ Description: Spotify - Get Saved Tracks
 Transform: 'AWS::Serverless-2016-10-31'
 Description: Spotify - Get Saved Tracks
 Resources:
+  Table:
+    Type: AWS::Serverless::SimpleTable
+    Properties: {}
   Lambda:
     Type: 'AWS::Serverless::Function'
     Properties:

--- a/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
+++ b/3_Utilities/shuffle-liked-tracks-playlist/template.yaml
@@ -20,6 +20,7 @@ Resources:
           SpotifyClientID: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyClientID
           SpotifyClientSecret: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyClientSecret
           SpotifyRefreshToken: !ImportValue spotify-tracker-sam-Parameters-1VQDTTBKRD7WJ-SpotifyRefreshToken
+          TableName: !Ref Table
       Events:
         EventBridge:
           Type: Schedule


### PR DESCRIPTION
This records the playlist id, url, and snapshot id of the new shuffled playlist.

The Spotify Web API Endpoint does not allow deletion of playlists. So, I tried to implement the recommended "unfollow" approach. I receive 401, so I must be missing a `scope`.

https://developer.spotify.com/documentation/general/guides/working-with-playlists/#following-and-unfollowing-a-playlist

