### PR TITLE
query-dynamodb-top - Add Internal Artist Id Lookup

### DIFF
--- a/3_Utilities/query-dynamodb-top/code/functions/dynamodb.py
+++ b/3_Utilities/query-dynamodb-top/code/functions/dynamodb.py
@@ -95,4 +95,8 @@ def get_artist_id(artist):
             }
         }
     )
-    return response['Item']['id']['S']
+
+    if 'Item' in response:
+        return response['Item']['id']['S']
+    else:
+        return None

--- a/3_Utilities/query-dynamodb-top/code/functions/dynamodb.py
+++ b/3_Utilities/query-dynamodb-top/code/functions/dynamodb.py
@@ -6,6 +6,8 @@ from .utils import get_current_year_month
 # table = os.environ['Table']
 table = 'spotify-tracker-sam-DynamoDB-153V5770W5PY5'
 table_top ='spotify-tracker-sam-DynamoDBTop-1VWZP135CNFSV'
+table_artist ='spotify-tracker-sam-artist-id'
+
 client = boto3.client('dynamodb', region_name='us-east-1')
 index = 'year_month-id-index'
 
@@ -83,3 +85,14 @@ def put(year_month, data):
                 },
             }
         )
+
+def get_artist_id(artist):
+    response = client.get_item(
+        TableName=table_artist,
+        Key={
+            'artist': {
+                'S': artist,
+            }
+        }
+    )
+    return response['Item']['id']['S']

--- a/3_Utilities/query-dynamodb-top/code/index.py
+++ b/3_Utilities/query-dynamodb-top/code/index.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from functions.dynamodb import query, put, get
+from functions.dynamodb import query, put, get, get_artist_id
 from functions.utils import parse_items, parse_query_string_parameters, get_current_year_month, create_pandas_data_frame
 
 def handler(event, context):
@@ -11,7 +11,10 @@ def handler(event, context):
     try:
         artist = event['queryStringParameters']['artist']
         artist_id = get_artist_id(artist)
-        return artist_id
+        print(artist, artist_id)
+        return {
+            'artist_id': artist_id
+        }
     except:
         pass
 

--- a/3_Utilities/query-dynamodb-top/code/index.py
+++ b/3_Utilities/query-dynamodb-top/code/index.py
@@ -6,6 +6,15 @@ from functions.utils import parse_items, parse_query_string_parameters, get_curr
 
 def handler(event, context):
     year_month = get_current_year_month()
+
+    # Handle artist lookup. Don't feel like doing a separate API...
+    try:
+        artist = event['queryStringParameters']['artist']
+        artist_id = get_artist_id(artist)
+        return artist_id
+    except:
+        pass
+
     # If no query parameters
     try:
         year_month, query_type = parse_query_string_parameters(event)

--- a/3_Utilities/query-dynamodb-top/template.yaml
+++ b/3_Utilities/query-dynamodb-top/template.yaml
@@ -17,6 +17,7 @@ Resources:
         Variables:
           Table: !ImportValue spotify-tracker-sam-TableName
           Top: !ImportValue spotify-tracker-sam-TableNameTop
+          Artist: !ImportValue spotify-tracker-sam-artist-id
       Events:
         HttpApiEvent:
           Type: HttpApi
@@ -28,3 +29,5 @@ Resources:
             TableName: !ImportValue spotify-tracker-sam-TableName
         - DynamoDBCrudPolicy:
             TableName: !ImportValue spotify-tracker-sam-TableNameTop
+        - DynamoDBCrudPolicy:
+            TableName: !ImportValue spotify-tracker-sam-artist-id

--- a/3_Utilities/query-dynamodb-top/template.yaml
+++ b/3_Utilities/query-dynamodb-top/template.yaml
@@ -17,7 +17,7 @@ Resources:
         Variables:
           Table: !ImportValue spotify-tracker-sam-TableName
           Top: !ImportValue spotify-tracker-sam-TableNameTop
-          Artist: !ImportValue spotify-tracker-sam-artist-id
+          Artist: spotify-tracker-sam-artist-id
       Events:
         HttpApiEvent:
           Type: HttpApi
@@ -30,4 +30,4 @@ Resources:
         - DynamoDBCrudPolicy:
             TableName: !ImportValue spotify-tracker-sam-TableNameTop
         - DynamoDBCrudPolicy:
-            TableName: !ImportValue spotify-tracker-sam-artist-id
+            TableName: spotify-tracker-sam-artist-id


### PR DESCRIPTION
Bit of a hokey workaround for #162 , but it works since the `artist_id` probably won't change. And since my data is a year old, going through and adding the artist_id key is a future problem.